### PR TITLE
(Issues exist) Upgrade  EncodingWithMESCustomPreset sample to track 2 SDK.

### DIFF
--- a/VideoEncoding/EncodingWithMESCustomPreset/pom.xml
+++ b/VideoEncoding/EncodingWithMESCustomPreset/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>sample</groupId>
   <artifactId>EncodingWithMESCustomPreset</artifactId>
@@ -14,35 +14,61 @@
       <version>1.1.1</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure.mediaservices.v2020_05_01</groupId>
-      <artifactId>azure-mgmt-media</artifactId>
-      <version>1.0.0-beta</version>
+      <groupId>com.azure.resourcemanager</groupId>
+      <artifactId>azure-resourcemanager-mediaservices</artifactId>
+      <version>1.1.0-beta.2</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.rest</groupId>
-      <artifactId>client-runtime</artifactId>
-      <version>1.6.8</version>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-client-authentication</artifactId>
-      <version>1.6.8</version>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-messaging-eventhubs</artifactId>
+      <version>5.10.3</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-arm-client-runtime</artifactId>
-      <version>1.6.8</version>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
+      <version>1.10.2</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-client-runtime</artifactId>
-      <version>1.6.8</version>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <version>1.21.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-sdk-bom</artifactId>
       <version>1.0.3</version>
       <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+      <version>12.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.10.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.10.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -53,11 +79,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.0.pr1</version>
     </dependency>
   </dependencies>
   <build>

--- a/VideoEncoding/EncodingWithMESCustomPreset/src/main/java/sample/EncodingWithMESCustomPreset.java
+++ b/VideoEncoding/EncodingWithMESCustomPreset/src/main/java/sample/EncodingWithMESCustomPreset.java
@@ -288,6 +288,16 @@ public class EncodingWithMESCustomPreset {
         return transform;
     }
 
+    /**
+     * Creates a new input Asset and uploads the specified local video file into it.
+     *
+     * @param manager           This is the entry point of Azure Media resource management.
+     * @param resourceGroupName The name of the resource group within the Azure subscription.
+     * @param accountName       The Media Services account name.
+     * @param assetName         The name of the asset where the media file to uploaded to.
+     * @param mediaFile         The path of a media file to be uploaded into the asset.
+     * @return The asset.
+     */
         private static Asset createInputAsset(MediaServicesManager manager, String resourceGroupName, String accountName,
                 String assetName, String mediaFile) throws Exception {
 

--- a/VideoEncoding/EncodingWithMESCustomPreset/src/main/java/sample/EncodingWithMESCustomPreset.java
+++ b/VideoEncoding/EncodingWithMESCustomPreset/src/main/java/sample/EncodingWithMESCustomPreset.java
@@ -441,7 +441,7 @@ public class EncodingWithMESCustomPreset {
 
         BlobContainerClient container =
                 new BlobContainerClientBuilder()
-                        .connectionString(assetContainerSas.assetContainerSasUrls().get(0))
+                        .endpoint(assetContainerSas.assetContainerSasUrls().get(0))
                         .buildClient();
 
         File directory = new File(outputFolder, assetName);


### PR DESCRIPTION
Issue remains:
reactor.core.Exceptions$ReactiveException: java.util.concurrent.TimeoutException: Channel response timed out after 60000 milliseconds.
